### PR TITLE
CI: Use 2.3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.3.1
-before_install: gem install bundler -v 1.16.2
+  - 2.3.8
+before_install: gem install bundler -v '< 2'


### PR DESCRIPTION
This PR updates the Ruby version used in the matrix, and installs a Bundler less than 2.0.

  - Also Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration